### PR TITLE
feat: add input field to allow user passing flags to `wf-recorder`

### DIFF
--- a/cute_sway_recorder/config_area.py
+++ b/cute_sway_recorder/config_area.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from typing import Optional, Union
 from PySide6 import QtCore
 
-from PySide6.QtWidgets import QCheckBox, QHBoxLayout, QLabel, QMessageBox, QSpinBox, QStyle, QVBoxLayout
+from PySide6.QtWidgets import QCheckBox, QHBoxLayout, QLabel, QMessageBox, QSpinBox, QStyle, QVBoxLayout, QLineEdit
 
 from .common import SelectedArea, SelectedScreen
 from .group_file_dest import FileDestGroup
@@ -16,6 +16,7 @@ class Config:
     file_dest: Path
     include_audio: bool
     delay: int
+    flags: str
 
 
 class ConfigArea(QVBoxLayout):
@@ -28,6 +29,7 @@ class ConfigArea(QVBoxLayout):
 
         self.checkbox_use_audio = QCheckBox("Record audio")
         self.delay_spinbox = QSpinBox()
+        self.flags = QLineEdit()
 
         self.setup_layout()
 
@@ -41,6 +43,11 @@ class ConfigArea(QVBoxLayout):
         bottom.addWidget(self.checkbox_use_audio)
         bottom.addStretch()
         self.addLayout(bottom)
+
+        flags = QHBoxLayout()
+        flags.addWidget(QLabel("Flags:"))
+        flags.addWidget(self.flags)
+        self.addLayout(flags)
 
     def create_config(self) -> Optional[Config]:
         """
@@ -63,7 +70,8 @@ class ConfigArea(QVBoxLayout):
             selection,
             self.file_dest_box.file_dest,
             self.checkbox_use_audio.isChecked(),
-            self.delay_spinbox.value()
+            self.delay_spinbox.value(),
+            self.flags.text()
         )
 
     def set_buttons_enabled(self, enabled: bool):

--- a/cute_sway_recorder/main.py
+++ b/cute_sway_recorder/main.py
@@ -43,8 +43,11 @@ def wf_recorder(
     of a screen or a whole screen.
 
     Saves the recording to file_dst, which is a path-like object.
+    Append user submitted flags to the end of params
+    Note: user can't enter parameters with spaces, e.g., --audio device1 device2
     """
     Path(file_dst).parent.mkdir(parents=True, exist_ok=True)
+    flags = flags.strip().split()
 
     params = ["wf-recorder", "-f", file_dst]
     if include_audio:
@@ -55,7 +58,7 @@ def wf_recorder(
     if isinstance(selection, SelectedScreen):
         params.append("--output")
         params.append(selection)
-    params.append(flags.strip())
+    params.extend(flags) # adds all items of flags to the end of params
     return subprocess.Popen(params)
 
 

--- a/cute_sway_recorder/main.py
+++ b/cute_sway_recorder/main.py
@@ -35,6 +35,7 @@ STOP_RECORDING = "Stop recording"
 def wf_recorder(
     selection: Union[SelectedArea, SelectedScreen],
     file_dst,
+    flags,
     include_audio: bool = False,
 ) -> subprocess.Popen:
     """
@@ -54,6 +55,7 @@ def wf_recorder(
     if isinstance(selection, SelectedScreen):
         params.append("--output")
         params.append(selection)
+    params.append(flags.strip())
     return subprocess.Popen(params)
 
 
@@ -194,6 +196,7 @@ class CuteRecorderQtApplication(QMainWindow):
         self.recorder_proc = wf_recorder(
             conf.selection,
             conf.file_dest,
+            conf.flags,
             include_audio=conf.include_audio,
         )
 


### PR DESCRIPTION
Hello @it-is-wednesday :)!

This PR is a follow-up of [Issue #28](https://github.com/it-is-wednesday/cute-sway-recorder/issues/28)

I have tested the following flags:

```
--force-yuv
--pixel-format yuv420p
-x yuv420p
-C ac3_fixed
```

I added each one to the `flag` input field. They are all successfully recognized by `wf-recorder`.

I tried specifying a video codec with the `-c <codec>` option, e.g., `-c h264_vaapi`, but `wf-recorder` doesn't seem to recognize it. Not sure why.

Thank you again!