### PR TITLE
lift 3.11 restriction

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -4,7 +4,7 @@ version = "6.2.2.1"
 description = "Python bindings for the Qt cross-platform application and UI framework"
 category = "main"
 optional = false
-python-versions = ">=3.6, <3.11"
+python-versions = ">=3.6, <3.12"
 
 [package.dependencies]
 shiboken6 = "6.2.2.1"
@@ -15,11 +15,11 @@ version = "6.2.2.1"
 description = "Python / C++ bindings helper module"
 category = "main"
 optional = false
-python-versions = ">=3.6, <3.11"
+python-versions = ">=3.6, <3.12"
 
 [metadata]
 lock-version = "1.1"
-python-versions = ">=3.6,<3.11" # PySide6 requirements
+python-versions = ">=3.6,<3.12" # PySide6 requirements
 content-hash = "7b43b1db09a55125f973c4b9f91e6d528d94259f5babe2b4dc53c577e6b9ac3f"
 
 [metadata.files]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 PySide6 = "6.*"
-python = ">=3.7,<3.11" # PySide6 requirements
+python = ">=3.7,<3.12" # PySide6 requirements
 
 [tool.poetry.scripts]
 cute-sway-recorder = "cute_sway_recorder.main:main"


### PR DESCRIPTION
Hello it-is-wednesday! Hope you're doing well.

I have upgraded to Python 3.11 and realized that `cute-sway-recorder` was not working.

This PR is to lift the 3.11 restriction.

Both shiboken6 and PySide6 support versions <3.12:

> https://pypi.org/project/shiboken6/
> Requires: Python <3.12, >=3.7
> 
> https://pypi.org/project/PySide6/
> Requires: Python <3.12, >=3.7

Tested with `pipx install git+https://github.com/kohane27/cute-sway-recorder@python-version`

```
➜ python --version
Python 3.11.3
➜ pipx --version
1.2.0
```

Please let me know if there's any further testing I should do! Thank you again for maintaining this very handy tool! Have a good day!