### PR TITLE
Feat/compositors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Cute Sway Recorder
 
-Screen recorder for [`wlroots`](https://gitlab.freedesktop.org/wlroots/wlroots/)-based window manager `Sway`. Do not work on `Hyperland`.
+Screen recorder for [`wlroots`](https://gitlab.freedesktop.org/wlroots/wlroots/)-based compositors like `Sway` and `Hyperland`. For other compositors, it falls back to using [wlr-randr](https://sr.ht/~emersion/wlr-randr/) to get outputs.
 
 More specifically, this project is merely a graphical [Qt](https://www.qt.io/) wrapper for [`wf-recorder`](https://github.com/ammen99/wf-recorder), leveraging [`slurp`](https://github.com/emersion/slurp) for selecting screen regions.
 
@@ -17,6 +17,24 @@ You might prefer using [pipx](https://pypa.github.io/pipx/):
 
 ```shell
 pipx install cute-sway-recorder
+```
+
+## Contributing
+
+PRs are welcome!
+
+1. After forking this repository, make sure to install the project dependencies locally:
+
+```bash
+poetry install
+```
+
+This will create a virtual environment and install all the required dependencies.
+
+2. Make sure `cute-sway-recorder` runs locally:
+
+```bash
+poetry run python -m cute_sway_recorder.main
 ```
 
 ## Alternatives

--- a/cute_sway_recorder/common.py
+++ b/cute_sway_recorder/common.py
@@ -1,32 +1,95 @@
 import json
 import re
+import os
 import subprocess
-from typing import List
+from typing import List, Optional
 
 
 PATTERN_SELECTED_AREA = re.compile(r"\d+,\d+ \d+x\d+")
 CONFIG_BUTTON_WIDTH = 130
 
 
-def available_screens() -> List[str]:
+def detect_compositor() -> Optional[str]:
     """
-    Returns a list of all available outputs via `swaymsg -t get_outputs`, e.g.:
-    ['eDP-1', 'HDMI-A-1']
+    Detects the running Wayland compositor.
     """
-    out = subprocess.check_output(["swaymsg", "-t", "get_outputs"], text=True)
-    return [o["name"] for o in json.loads(out)]
+    if "SWAYSOCK" in os.environ:
+        return "sway"
+    elif "HYPRLAND_INSTANCE_SIGNATURE" in os.environ:
+        return "hyprland"
+    else:
+        try:
+            subprocess.run(
+                "wlr-randr",
+                check=True,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            return "wlr-randr"
+        except FileNotFoundError:
+            raise ValueError(
+                "Unsupported Wayland compositor. Please install wlr-randr for additional support."
+            )
+
+
+def apply_compositor_rules(compositor: str):
+    """
+    Applies compositor-specific window rules.
+    """
+    if compositor == "sway":
+        subprocess.run(
+            ["swaymsg", 'for_window [app_id="cute-sway-recorder"] floating enable']
+        )
+    elif compositor == "hyprland":
+        subprocess.run(
+            ["hyprctl", "keyword", "windowrulev2", "float,class:^(cute-sway-recorder)$"]
+        )
+    elif compositor == "wlr-randr":
+        # No specific window rules for wlr-randr
+        return
+    else:
+        raise ValueError(f"Unsupported Wayland compositor: {compositor}")
+
+
+def get_available_screens(compositor: str) -> List[str]:
+    """
+    Returns a list of available outputs based on the compositor,
+    e.g., ['eDP-1', 'HDMI-A-1']
+    """
+    if compositor == "sway":
+        command = ["swaymsg", "-t", "get_outputs"]
+    elif compositor == "hyprland":
+        command = ["hyprctl", "-j", "monitors"]
+    elif compositor == "wlr-randr":
+        command = ["wlr-randr", "--json"]
+    else:
+        raise ValueError(f"Unsupported Wayland compositor: {compositor}")
+
+    try:
+        output = subprocess.check_output(command, text=True)
+        screens = json.loads(output)
+        return [screen["name"] for screen in screens]
+    except (subprocess.CalledProcessError, json.JSONDecodeError) as e:
+        raise RuntimeError(f"Failed to retrieve available screens: {str(e)}") from e
 
 
 class SelectedScreen(str):
     """
     Textual representation of one of your monitors. Raises ValueError if instantiated with a string
-    which isn't one of the monitors. List of monitors is decided by `available_screens()`.
+    which isn't one of the monitors. List of monitors is decided by `get_available_screens()`.
     """
 
     def __init__(self, s):
-        screens = available_screens()
-        if s not in screens:
-            raise ValueError(f"Screen {s} isn't one of available screens: {screens}")
+        try:
+            compositor = detect_compositor()
+            apply_compositor_rules(compositor)
+            screens = get_available_screens(compositor)
+            if s not in screens:
+                raise ValueError(
+                    f"Screen '{s}' isn't one of the available screens: {screens}"
+                )
+        except Exception as e:
+            raise RuntimeError(f"An unexpected error occurred: {str(e)}") from e
 
 
 class SelectedArea(str):

--- a/cute_sway_recorder/group_selection.py
+++ b/cute_sway_recorder/group_selection.py
@@ -3,13 +3,19 @@ from typing import Optional, Union
 
 from PySide6.QtWidgets import QHBoxLayout, QLabel, QPushButton, QVBoxLayout
 
-from .common import CONFIG_BUTTON_WIDTH, SelectedArea, SelectedScreen, available_screens
+from .common import (
+    CONFIG_BUTTON_WIDTH,
+    SelectedArea,
+    SelectedScreen,
+    get_available_screens,
+    detect_compositor,
+)
 from .select_screen import ScreenSelectionDialog
 
 
 def select_area() -> Optional[SelectedArea]:
     """
-    Launch slurp to capture a region of the screen, returns its output in the following format:
+    Launch slurp to capture a region of the screen, and returns its output in the following format:
     <x>,<y> <width>x<height>
 
     If slurp is cancelled (by hitting escape), returns None
@@ -39,7 +45,9 @@ class SelectionGroup(QVBoxLayout):
 
         self.btn_select_area = QPushButton("Select area")
         self.btn_select_whole_screen = QPushButton(
-            "Select screen" if len(available_screens()) > 1 else "Whole screen"
+            "Select screen"
+            if len(get_available_screens(detect_compositor())) > 1
+            else "Whole screen"
         )
 
         self.btn_select_area.clicked.connect(self.btn_onclick_select_area)
@@ -68,7 +76,7 @@ class SelectionGroup(QVBoxLayout):
         self.lbl_whole_screen_notice.hide()
 
     def btn_onclick_select_whole_screen(self):
-        screens = available_screens()
+        screens = get_available_screens(detect_compositor())
         if len(screens) > 1:
             selected_screen_idx = ScreenSelectionDialog(
                 screens, parent=self.window

--- a/cute_sway_recorder/main.py
+++ b/cute_sway_recorder/main.py
@@ -77,26 +77,26 @@ class CuteRecorderQtApplication(QMainWindow):
         self.setWindowTitle("Cute Sway Recorder")
         self.config_area = ConfigArea(self)
 
-        ## Create labels
+        # Create labels
         self.lbl_status = QLabel("Not recording")
 
-        ## Create buttons
+        # Create buttons
         self.btn_start_recording = QPushButton("Start recording")
         self.btn_stop_recording = QPushButton(STOP_RECORDING)
 
-        ## Connect buttons on-click actions
+        # Connect buttons on-click actions
         self.btn_start_recording.clicked.connect(self.btn_onclick_start_recording)
         self.btn_stop_recording.clicked.connect(self.btn_onclick_stop_recording)
         self.btn_stop_recording.setEnabled(False)
 
-        ## Verify executable dependencies
+        # Verify executable dependencies
         self.cmd_available_or_exit("wf-recorder")
         self.cmd_available_or_exit("slurp")
 
-        ## Setup layout
+        # Setup layout
         self.setup_layout()
 
-        ## Define whole-screen icon (not showing yet)
+        # Define whole-screen icon (not showing yet)
         self.icon = QSystemTrayIcon(self)
         self.icon.setIcon(self.style().standardIcon(QStyle.SP_MediaStop))
         self.icon.activated.connect(self.tray_icon_activated_handler)
@@ -219,9 +219,6 @@ class CuteRecorderQtApplication(QMainWindow):
 
 
 def main():
-    subprocess.run(
-        ["swaymsg", 'for_window [app_id="cute-sway-recorder"] floating enable']
-    )
     app = QApplication(sys.argv)
     app.setApplicationDisplayName("Cute Sway Recorder")
     app.setDesktopFileName("cute-sway-recorder")


### PR DESCRIPTION
Hello! I've added support for multiple compositors. Basically, it just checks whether the user is using `Sway` or `Hyprland`. If not, it'll try to use `wlr-randr` to get the output. I have tried on `Sway` and `Hyprland`, and they work (to the extend on my machine). I tried running with `wlr-randr` and it also works.

Hopefully I will get your input before merging to `master`. Afterwards, I'll make a new release.

Side note: I'm not sure about renaming it to `cute-wlroots-recorder`: since it's already released on pypi and it seems to be more complicated; I don't want to break current user experience. Thank you again!
