### PR TITLE
WIP: Added support for configuration file parsing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,32 @@ You might prefer using [pipx](https://pypa.github.io/pipx/):
 pipx install cute-sway-recorder
 ```
 
+## Configuration
+
+Default configuration is stored in the file `$HOME/.config/cute-sway-recorder/config.ini`
+in [ini](https://docs.python.org/3/library/configparser.html#supported-ini-file-structure) format.
+
+Here is an example configuration which saves recordings as gifs:
+
+```ini
+[wf-recorder-defaults]
+# Default file save location (location must exist)
+# Type: string, default: "~/Videos/cute-{id}.mp4"
+file_dest = ~/Gifs/gif.gif
+
+# Whether to include audio in recording
+# Type: bool, default: off
+include_audio = off
+
+# Delay before recording starts 
+# Type: integer, default: 0
+delay = 0
+
+# Additional flags to pass to wf-recorder
+# Type: string, default: ""
+flags = -c gif -r 10
+```
+
 ## Contributing
 
 PRs are welcome!

--- a/cute_sway_recorder/config_area.py
+++ b/cute_sway_recorder/config_area.py
@@ -12,6 +12,7 @@ from PySide6.QtWidgets import (
     QLineEdit,
 )
 
+from .config_file import ConfigFile
 from .common import SelectedArea, SelectedScreen
 from .group_file_dest import FileDestGroup
 from .group_selection import SelectionGroup
@@ -31,14 +32,22 @@ class ConfigArea(QVBoxLayout):
         super().__init__()
         self.window = window
 
+        config_file = ConfigFile.parse()
+
         self.selection_box = SelectionGroup(window)
-        self.file_dest_box = FileDestGroup(window)
+        self.file_dest_box = FileDestGroup(window, config_file)
 
         self.checkbox_use_audio = QCheckBox("Record audio")
         self.delay_spinbox = QSpinBox()
         self.flags = QLineEdit()
 
+        self.set_defaults(config_file)
         self.setup_layout()
+
+    def set_defaults(self, config_file: ConfigFile):
+        self.checkbox_use_audio.setChecked(config_file.include_audio)
+        self.delay_spinbox.setValue(config_file.delay)
+        self.flags.setText(config_file.flags)
 
     def setup_layout(self):
         self.addLayout(self.selection_box)

--- a/cute_sway_recorder/config_file.py
+++ b/cute_sway_recorder/config_file.py
@@ -55,6 +55,8 @@ class ConfigFile:
             except configparser.ParsingError as e:
                 print_error(e)
                 return config_file
+        else:
+            return config_file
 
         config_file.flags = parser.get("DEFAULT", "flags", fallback="") 
 

--- a/cute_sway_recorder/config_file.py
+++ b/cute_sway_recorder/config_file.py
@@ -3,7 +3,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
 
-DEFAULT_CONFIG_PATH = Path.home() / ".config" / "cute-sway-recorder" / "defaults.conf"
+DEFAULT_CONFIG_PATH = Path.home() / ".config" / "cute-sway-recorder" / "config.ini"
+CONFIG_SECTION = "wf-recorder-defaults"
 
 def validate_file_dest(file_dest: Path):
     """
@@ -11,7 +12,7 @@ def validate_file_dest(file_dest: Path):
     is a valid destination.
     Namely
      - It is not a directory
-     - It's parent is an existing directory
+     - Its parent is an existing directory
     """
     if len(file_dest.name) == 0:
         raise ValueError(f"\"{file_dest}\" does not have a name.")
@@ -48,7 +49,6 @@ class ConfigFile:
         config_file = ConfigFile()
 
         parser = configparser.ConfigParser()
-
         if config_file_path.exists(): 
             try:
                 parser.read(config_file_path)
@@ -58,22 +58,22 @@ class ConfigFile:
         else:
             return config_file
 
-        config_file.flags = parser.get("DEFAULT", "flags", fallback="") 
+        config_file.flags = parser.get(CONFIG_SECTION, "flags", fallback="") 
 
         try:
-            config_file.include_audio = parser.getboolean("DEFAULT", "include_audio", fallback=False)
+            config_file.include_audio = parser.getboolean(CONFIG_SECTION, "include_audio", fallback=False)
         except ValueError as e:
             print_error(e, "include_audio")
 
         try:
-            delay = parser.getint("DEFAULT", "delay", fallback=0)
+            delay = parser.getint(CONFIG_SECTION, "delay", fallback=0)
             if delay < 0:
                 raise ValueError(f"expected nonnegative, got {delay}")
             config_file.delay = delay
         except ValueError as e:
             print_error(e, "delay")
 
-        file_dest_str = parser.get("DEFAULT", "file_dest", fallback=None)
+        file_dest_str = parser.get(CONFIG_SECTION, "file_dest", fallback=None)
         if file_dest_str is not None:
             try:
                 file_dest = Path(file_dest_str)

--- a/cute_sway_recorder/config_file.py
+++ b/cute_sway_recorder/config_file.py
@@ -1,0 +1,64 @@
+import configparser
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+DEFAULT_CONFIG_PATH = Path.home() / ".config" / "cute-sway-recorder" / "defaults.conf"
+
+def validate_file_dest(file_dest: Path):
+    """
+    Tests if a file destination coming from the config file
+    is a valid destination.
+    Namely
+     - It is not a directory
+     - It's parent is an existing directory
+    """
+    if len(file_dest.name) == 0:
+        raise ValueError(f"\"{file_dest}\" does not have a name.")
+
+    if file_dest.is_dir():
+        raise ValueError(f"\"{file_dest}\" is a directory.")
+
+    if not file_dest.parents[0].expanduser().is_dir():
+        raise ValueError(f"\"{file_dest}\"'s parent directory does not exist.")
+
+@dataclass
+class ConfigFile:
+    """
+    Contains data parsed from the config file 
+    at `~/.config/cute-sway-recording/defaults.conf`
+    Use :func:`ConfigFile.parse` to parse the ConfigFile.
+    """
+
+    file_dest: Optional[Path] = None
+    include_audio: bool = False
+    delay: int = 0
+    flags: str = ""
+
+    @staticmethod
+    def parse(config_file_path: Path = DEFAULT_CONFIG_PATH) -> "ConfigFile":
+        parser = configparser.ConfigParser()
+
+        if config_file_path.exists(): 
+            try:
+                parser.read(config_file_path)
+            except configparser.ParsingError as e:
+                print(f"Error parsing config: {e}")
+
+        config_file = ConfigFile(
+            include_audio = parser.getboolean("DEFAULT", "include_audio", fallback=False),
+            delay = parser.getint("DEFAULT", "delay", fallback=0),
+            flags = parser.get("DEFAULT", "flags", fallback=""),
+        )
+
+        file_dest_str = parser.get("DEFAULT", "file_dest", fallback=None)
+        if file_dest_str is not None:
+            try:
+                file_dest = Path(file_dest_str)
+                validate_file_dest(file_dest)
+                config_file.file_dest = file_dest.expanduser().resolve()
+            except ValueError as e:
+                print(f"Error parsing config: {e}")
+                
+
+        return config_file

--- a/cute_sway_recorder/group_file_dest.py
+++ b/cute_sway_recorder/group_file_dest.py
@@ -2,6 +2,7 @@ import random
 import re
 import string
 from pathlib import Path
+from typing import Optional
 
 from PySide6.QtWidgets import (
     QFileDialog,
@@ -10,6 +11,7 @@ from PySide6.QtWidgets import (
     QPushButton,
 )
 
+from .config_area import ConfigFile
 from .common import CONFIG_BUTTON_WIDTH
 
 PATTERN_FILE_WITH_SUFFIX = re.compile(r".*\..*")
@@ -36,12 +38,11 @@ def make_default_file_dest() -> Path:
 
 
 class FileDestGroup(QHBoxLayout):
-    def __init__(self, window):
+    def __init__(self, window, config_file: ConfigFile):
         super().__init__()
         self.window = window
 
-        self.file_dest = make_default_file_dest()
-
+        self.file_dest = config_file.file_dest or make_default_file_dest()
         self.lbl_file_dst = QLabel()
         self.update_file_dest_label()
 


### PR DESCRIPTION
Hello :D!!! I was working on #35 and have a draft. 

I created a new dataclass for the parsed config (called `ConfigFile`). It includes everything in `Config` except `selection` (I wasn't sure how I'd include it).

I tested `file_dest`s with/without `~` and made sure it doesn't accept directories, paths without names (`/`), or paths without an existing parent directory.
It also rejects negative/non-integer `delay` values and non-bool-like `include_audio` values.
When it rejects a value, it *should* print a descriptive error to console and continue running without throwing!

@kohane27 If you could help test I would greatly appreciate :3

closes #35 