### PR TITLE
chore: use `poetry-core` in build-system

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,8 +16,8 @@ python = ">=3.8,<3.13" # PySide6 requirements
 cute-sway-recorder = "cute_sway_recorder.main:main"
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
 
 [tool.ruff]
 # Same as Black.


### PR DESCRIPTION
Hello! I'm back!

As suggested in https://python-poetry.org/docs/pyproject/#poetry-and-pep-517:

> If your pyproject.toml file still references poetry directly as a build backend, you should update it to reference poetry-core instead.