### PR TITLE
chore: add quote surrounding string

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Here is an example configuration which saves recordings as gifs:
 [wf-recorder-defaults]
 # Default file save location (location must exist)
 # Type: string, default: "~/Videos/cute-{id}.mp4"
-file_dest = ~/Gifs/gif.gif
+file_dest = "~/Gifs/gif.gif"
 
 # Whether to include audio in recording
 # Type: bool, default: off


### PR DESCRIPTION
Without quote, the following would just output cute-`{id}.mp4`

```
[wf-recorder-defaults]
file_dest = ~/Videos/cute-{id}.mp4
```
