### PR TITLE
fix(config): replace "{id}" with `make_random_file_stem()`

### DIFF
--- a/cute_sway_recorder/common.py
+++ b/cute_sway_recorder/common.py
@@ -1,8 +1,10 @@
+from typing import List, Optional
 import json
 import re
 import os
 import subprocess
-from typing import List, Optional
+import random
+import string
 
 
 PATTERN_SELECTED_AREA = re.compile(r"\d+,\d+ \d+x\d+")
@@ -111,3 +113,13 @@ class SelectedArea(str):
     def __init__(self, s):
         if not PATTERN_SELECTED_AREA.match(s):
             raise ValueError(f"Area '{s}' isn't of format: 'x,y width,height'")
+
+
+def make_random_file_stem() -> str:
+    """
+    Create a default basename (no extension, no path) for default videos to be used by
+    make_default_file_dest and "Random Name"
+    Example result: cute-sbh42
+    """
+    identifier = "".join(random.choices(string.ascii_letters, k=5))
+    return f"cute-{identifier}"

--- a/cute_sway_recorder/config_file.py
+++ b/cute_sway_recorder/config_file.py
@@ -2,6 +2,7 @@ import configparser
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
+from .common import make_random_file_stem
 
 DEFAULT_CONFIG_PATH = Path.home() / ".config" / "cute-sway-recorder" / "config.ini"
 CONFIG_SECTION = "wf-recorder-defaults"
@@ -76,7 +77,12 @@ class ConfigFile:
         file_dest_str = parser.get(CONFIG_SECTION, "file_dest", fallback=None)
         if file_dest_str is not None:
             try:
-                file_dest = Path(file_dest_str)
+                if "{id}" in file_dest_str:
+                    replaced_str = file_dest_str.replace("{id}", make_random_file_stem())
+                    file_dest = Path(replaced_str)
+                else:
+                    file_dest = Path(file_dest_str)
+
                 validate_file_dest(file_dest)
                 config_file.file_dest = file_dest.expanduser().resolve()
             except ValueError as e:

--- a/cute_sway_recorder/group_file_dest.py
+++ b/cute_sway_recorder/group_file_dest.py
@@ -1,6 +1,4 @@
-import random
 import re
-import string
 from pathlib import Path
 from typing import Optional
 
@@ -12,7 +10,7 @@ from PySide6.QtWidgets import (
 )
 
 from .config_area import ConfigFile
-from .common import CONFIG_BUTTON_WIDTH
+from .common import CONFIG_BUTTON_WIDTH, make_random_file_stem
 
 PATTERN_FILE_WITH_SUFFIX = re.compile(r".*\..*")
 
@@ -24,15 +22,6 @@ def shrink_home(path: str) -> str:
     """
     return path.replace(str(Path.home()), "~")
 
-
-def make_random_file_stem() -> str:
-    """
-    Create a default basename (no extension, no path) for default videos to be used by
-    make_default_file_dest and "Random Name"
-    Example result: cute-sbh42
-    """
-    identifier = "".join(random.choices(string.ascii_letters, k=5))
-    return f"cute-{identifier}"
 
 def make_default_file_dest() -> Path:
     """


### PR DESCRIPTION
## Description

I tried to change the file destination:

```
file_dest = ~/Temp/videos/cute-{id}.mp4
```

I realized it does not expand `{id}`, i.e., the filename becomes the literal `cute-{id}.mp4`.

## Changes

This PR ensures the following behavior:

1. If the user does not provide `file_dest`, we default to the sensible `~/Videos/cute-NOwPn.mp4`.

2. If the user provides `file_dest`, like `file_dest = ~/Temp/videos/{id}.mp4`, we expand it to `~/Temp/videos/cute-NOwPn.mp4`

Thank you!